### PR TITLE
Bump to v4.7.0, require OpenCV_jll 4.13.0+0

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - 'min'
-          - '1.11'
+          - '1.12'
         os:
           - ubuntu-latest
           - windows-latest
@@ -28,7 +28,7 @@ jobs:
         include:
           - os: macOS-latest
             arch: aarch64
-            version: '1.11'
+            version: '1.12'
 
     steps:
       - uses: actions/checkout@v6
@@ -46,13 +46,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   multithreads:
-    name: Julia (threads) 1.11 - ubuntu-latest - x64 - ${{ github.event_name }}
+    name: Julia (threads) 1.12 - ubuntu-latest - x64 - ${{ github.event_name }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.11'
+          version: '1.12'
           arch: 'x64'
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.11'
+          version: '1.12'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenCV"
 uuid = "f878e3a2-a245-4720-8660-60795d644f2a"
 authors = ["Archit Rungta <architrungta120@gmail.com>"]
-version = "4.6.2"
+version = "4.7.0"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
@@ -11,5 +11,5 @@ OpenCV_jll = "33b9d88c-85f9-5d73-bd91-4e2b95a9aa0b"
 [compat]
 CxxWrap = "0.16, 0.17"
 FileIO = "1.16, 1.17"
-OpenCV_jll = "4.10.0"
+OpenCV_jll = "4.13"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@
 
 **OpenCV.jl** is a Julia package that provides an interface to the popular computer vision library OpenCV. It allows Julia users to leverage the extensive functionalities and algorithms offered by OpenCV for various computer vision tasks, such as image and video processing, object detection, feature extraction, and more.
 
-> [!NOTE]
-> **OpenCV.jl 4.7 requires `OpenCV_jll 4.13.0+0` or newer**, which is built against `CxxWrap` 0.17 / `libcxxwrap_julia_jll` 0.14 and supports Julia 1.10–1.14. Earlier `OpenCV_jll` versions are no longer compatible.
-
 ## Features
 
 - Comprehensive OpenCV bindings: OpenCV.jl provides comprehensive bindings to the OpenCV library, enabling Julia users to access a wide range of computer vision algorithms and functionalities.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 **OpenCV.jl** is a Julia package that provides an interface to the popular computer vision library OpenCV. It allows Julia users to leverage the extensive functionalities and algorithms offered by OpenCV for various computer vision tasks, such as image and video processing, object detection, feature extraction, and more.
 
-> [!WARNING]
-> **OpenCV.jl currently only works on Julia 1.10 and 1.11.** The underlying `OpenCV_jll 4.10.0+0` binary links against `CxxWrap` 0.16 / `libcxxwrap_julia_jll` 0.13, neither of which supports Julia 1.12+. Support for newer Julia versions is blocked on [OpenCV_jll 4.12.0+0](https://github.com/JuliaPackaging/Yggdrasil/pull/12551) being published.
+> [!NOTE]
+> **OpenCV.jl 4.7 requires `OpenCV_jll 4.13.0+0` or newer**, which is built against `CxxWrap` 0.17 / `libcxxwrap_julia_jll` 0.14 and supports Julia 1.10–1.14. Earlier `OpenCV_jll` versions are no longer compatible.
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Narrow `OpenCV_jll` compat to `4.13` (drop the old `4.10.0` floor).
- Bump OpenCV.jl version `4.6.2` → `4.7.0`.
- Update the README warning: with the new JLL, Julia 1.10–1.14 are all supported and no manual pinning is needed.

`OpenCV_jll 4.13.0+0` ([JuliaPackaging/Yggdrasil#13849](https://github.com/JuliaPackaging/Yggdrasil/pull/13849), merged) is the first published JLL that:
- builds against `CxxWrap` 0.17 / `libcxxwrap_julia_jll` 0.14 (so it loads on Julia 1.12+);
- carries the OpenCV 4.13 generator fixes for nested-enum properties (CirclesGridFinderParameters::GridType), `cvtColor`/`GaussianBlur` keyword shims (new `AlgorithmHint` parameter), `imread` defaults (`IMREAD_COLOR_BGR`), and `Subdiv2D` Rect2f signatures.

Older `OpenCV_jll` versions either pin libcxxwrap 0.13 (won't load on Julia 1.12+) or are missing the 4.11–4.13 generator fixes, so the same OpenCV.jl source can't actually be used against them — narrowing compat to `4.13` codifies what already works.

## Test plan

- [x] Full test suite passes **157/157** against `OpenCV_jll 4.13.0+0` on Julia 1.12 with `CxxWrap 0.17.5` + `libcxxwrap_julia_jll 0.14.10`.
- [ ] CI confirms across the supported Julia matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)