### PR TITLE
Accept covariant Vector{<:InputArray} in calibrateCamera variants

### DIFF
--- a/src/OpenCV.jl
+++ b/src/OpenCV.jl
@@ -7,6 +7,7 @@ using FileIO: DataFormat, File, Stream, stream
 include(joinpath(OpenCV_jll.artifact_dir, "OpenCV", "src", "OpenCV.jl"))
 
 include("patches_video.jl")
+include("patches.jl")
 include("fileio.jl")
 include("show.jl")
 

--- a/src/patches.jl
+++ b/src/patches.jl
@@ -1,0 +1,42 @@
+## Hand-written overloads on top of the auto-generated wrappers.
+##
+## The auto-generated signatures in `OpenCV_jll` use the invariant type
+## `Array{InputArray, 1}` for vector-of-array arguments. Julia's parametric
+## types are invariant, so concrete inputs like `Vector{Array{Float32, 3}}`
+## fail to dispatch, even though `Array{Float32, 3} <: InputArray`. We add
+## thin covariant overloads here that accept `AbstractVector{<:InputArray}`
+## and convert to `Vector{InputArray}` before forwarding to the wrapper.
+
+_as_input_vec(v::AbstractVector{<:InputArray}) = collect(InputArray, v)
+
+# Issue #60: calibrateCamera and its variants.
+for f in (:calibrateCamera, :calibrateCameraExtended)
+    @eval function $f(objectPoints::AbstractVector{<:InputArray},
+                      imagePoints::AbstractVector{<:InputArray},
+                      imageSize::Size{Int32},
+                      cameraMatrix::InputArray,
+                      distCoeffs::InputArray,
+                      rvecs::AbstractVector{<:InputArray},
+                      tvecs::AbstractVector{<:InputArray},
+                      args...)
+        $f(_as_input_vec(objectPoints), _as_input_vec(imagePoints),
+           imageSize, cameraMatrix, distCoeffs,
+           _as_input_vec(rvecs), _as_input_vec(tvecs), args...)
+    end
+end
+
+for f in (:calibrateCameraRO, :calibrateCameraROExtended)
+    @eval function $f(objectPoints::AbstractVector{<:InputArray},
+                      imagePoints::AbstractVector{<:InputArray},
+                      imageSize::Size{Int32},
+                      iFixedPoint::Int64,
+                      cameraMatrix::InputArray,
+                      distCoeffs::InputArray,
+                      rvecs::AbstractVector{<:InputArray},
+                      tvecs::AbstractVector{<:InputArray},
+                      args...)
+        $f(_as_input_vec(objectPoints), _as_input_vec(imagePoints),
+           imageSize, iFixedPoint, cameraMatrix, distCoeffs,
+           _as_input_vec(rvecs), _as_input_vec(tvecs), args...)
+    end
+end

--- a/test/test_calibration.jl
+++ b/test/test_calibration.jl
@@ -55,3 +55,38 @@ end
 
 end
 
+@testset "issue #60: concrete Vector{Array{T,3}} dispatch" begin
+    # Without the covariant overloads in src/patches.jl, callers had to use
+    # `OpenCV.InputArray[…]` element-typed vectors. Confirm that natural
+    # `Vector{Array{Float32,3}}` inputs now dispatch.
+    objpts = [Float32.(reshape(stack(Tuple.(CartesianIndices((0:5, 0:4, 0:0)))), 3, 1, :)) for _ in 1:2]
+    imgpts = [rand(Float32, 2, 1, length(first(objpts)) ÷ 3) for _ in 1:2]
+    @test objpts isa Vector{Array{Float32, 3}}
+    rvecs = [zeros(Float64, 1, 1, 3) for _ in 1:2]
+    tvecs = [zeros(Float64, 1, 1, 3) for _ in 1:2]
+    @test rvecs isa Vector{Array{Float64, 3}}
+    @test_nowarn applicable(OpenCV.calibrateCamera, objpts, imgpts,
+                            OpenCV.Size{Int32}(640, 480),
+                            OpenCV.Mat(zeros(Float64, 1, 3, 3)),
+                            OpenCV.Mat(zeros(Float64, 1, 1, 5)),
+                            rvecs, tvecs, 0,
+                            OpenCV.TermCriteria(3, 30, 0.001))
+    @test hasmethod(OpenCV.calibrateCamera,
+                    Tuple{Vector{Array{Float32,3}}, Vector{Array{Float32,3}},
+                          OpenCV.Size{Int32}, OpenCV.Mat{Float64}, OpenCV.Mat{Float64},
+                          Vector{Array{Float64,3}}, Vector{Array{Float64,3}},
+                          Int, OpenCV.TermCriteria})
+    @test hasmethod(OpenCV.calibrateCameraExtended,
+                    Tuple{Vector{Array{Float32,3}}, Vector{Array{Float32,3}},
+                          OpenCV.Size{Int32}, OpenCV.Mat{Float64}, OpenCV.Mat{Float64},
+                          Vector{Array{Float64,3}}, Vector{Array{Float64,3}}})
+    @test hasmethod(OpenCV.calibrateCameraRO,
+                    Tuple{Vector{Array{Float32,3}}, Vector{Array{Float32,3}},
+                          OpenCV.Size{Int32}, Int, OpenCV.Mat{Float64}, OpenCV.Mat{Float64},
+                          Vector{Array{Float64,3}}, Vector{Array{Float64,3}}})
+    @test hasmethod(OpenCV.calibrateCameraROExtended,
+                    Tuple{Vector{Array{Float32,3}}, Vector{Array{Float32,3}},
+                          OpenCV.Size{Int32}, Int, OpenCV.Mat{Float64}, OpenCV.Mat{Float64},
+                          Vector{Array{Float64,3}}, Vector{Array{Float64,3}}})
+end
+


### PR DESCRIPTION
## Summary
- The auto-generated wrappers declare positional vector args as the invariant `Array{InputArray, 1}`, so concrete inputs like `Vector{Array{Float32, 3}}` fail to dispatch even though the element type satisfies `<: InputArray`.
- Adds thin covariant overloads in a new `src/patches.jl` (now wired into `OpenCV.jl`) that accept `AbstractVector{<:InputArray}` and forward to the wrapper after `collect`-converting to `Vector{InputArray}`.
- Scoped to the four functions the issue explicitly names: `calibrateCamera`, `calibrateCameraExtended`, `calibrateCameraRO`, `calibrateCameraROExtended`. Other functions with the same root cause (`polylines`, `imdecode`, etc.) will be handled in follow-up PRs.

Fixes #60.

## Test plan
- [x] Local `Pkg.test()` passes (164 tests, +7 new in `test_calibration.jl`).
- [x] Regression test confirms `Vector{Array{Float32, 3}}` and `Vector{Array{Float64, 3}}` inputs dispatch to all four functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)