### PR TITLE
Accept covariant Vector{<:InputArray} in polylines, fillPoly, drawContours

### DIFF
--- a/src/OpenCV.jl
+++ b/src/OpenCV.jl
@@ -8,6 +8,7 @@ include(joinpath(OpenCV_jll.artifact_dir, "OpenCV", "src", "OpenCV.jl"))
 
 include("patches_video.jl")
 include("patches.jl")
+include("patches_drawing.jl")
 include("fileio.jl")
 include("show.jl")
 

--- a/src/patches_drawing.jl
+++ b/src/patches_drawing.jl
@@ -1,0 +1,24 @@
+## Covariant Vector overloads for drawing functions whose auto-generated
+## signatures use the invariant `Array{InputArray, 1}` and therefore reject
+## natural inputs like `Vector{Array{Int32, 3}}`. See issue #18.
+
+_as_input_vec_drawing(v::AbstractVector{<:InputArray}) = collect(InputArray, v)
+
+function polylines(img::InputArray,
+                   pts::AbstractVector{<:InputArray},
+                   isClosed::Bool, color::Scalar, args...; kwargs...)
+    polylines(img, _as_input_vec_drawing(pts), isClosed, color, args...; kwargs...)
+end
+
+function fillPoly(img::InputArray,
+                  pts::AbstractVector{<:InputArray},
+                  color::Scalar, args...; kwargs...)
+    fillPoly(img, _as_input_vec_drawing(pts), color, args...; kwargs...)
+end
+
+function drawContours(image::InputArray,
+                      contours::AbstractVector{<:InputArray},
+                      contourIdx::Int64, color::Scalar, args...; kwargs...)
+    drawContours(image, _as_input_vec_drawing(contours), contourIdx, color,
+                 args...; kwargs...)
+end

--- a/test/test_imgproc.jl
+++ b/test/test_imgproc.jl
@@ -22,3 +22,16 @@ ve_gray = OpenCV.cvtColor(ve, OpenCV.COLOR_RGB2GRAY)
 
 # Shape check
 @test size(ve_gray)[1] == 1 && size(img_gray)[1] == 1
+
+@testset "issue #18: drawing functions accept Vector{Array{Int32,3}}" begin
+    # Without the covariant overloads in src/patches_drawing.jl, callers had
+    # to construct `OpenCV.InputArray[…]` element-typed vectors. Confirm that
+    # a natural `Vector{Array{Int32,3}}` dispatches.
+    canvas = OpenCV.Mat(zeros(UInt8, 3, 64, 64))
+    pts_array = Int32.(reshape([10 5; 20 30; 50 20; 30 10]', 2, 1, 4))
+    pts = [pts_array]
+    @test pts isa Vector{Array{Int32, 3}}
+    @test_nowarn OpenCV.polylines(canvas, pts, false, (0, 255, 255); thickness=1)
+    @test_nowarn OpenCV.fillPoly(canvas, pts, (255, 0, 0))
+    @test_nowarn OpenCV.drawContours(canvas, pts, -1, (0, 255, 0))
+end


### PR DESCRIPTION
## Summary
- Same root cause as #71 (issue #60): auto-generated wrappers use the invariant `Array{InputArray, 1}` in positional arguments, blocking dispatch of natural inputs like `Vector{Array{Int32, 3}}`.
- Adds covariant overloads for the imgproc drawing functions `polylines`, `fillPoly`, and `drawContours` in a new `src/patches_drawing.jl`.
- The new file is parallel to (and independent of) `src/patches.jl` introduced in #71; the only conflicting hunk between the two PRs is the `include` line in `OpenCV.jl`.

Fixes #18.

## Test plan
- [x] Local `Pkg.test()` passes (161 tests, +4 new in `test_imgproc.jl`).
- [x] Reproducer from the issue dispatches successfully (verified separately with a properly-shaped `(2, 1, N)` Int32 contour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)