### PR TITLE
Accept Vector{UInt8} buffer in imdecode

### DIFF
--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -56,3 +56,12 @@ function save(s::Stream{T}, image::InputArray, params::Vector{Int32}) where {T<:
     Base.write(stream(s), enc_img)
 end
 
+## Issue #58: the auto-generated `imdecode(buf::InputArray, flags::Int64)`
+## requires the encoded byte buffer to already be a 3D `InputArray`, but the
+## natural form returned by `imencode`, file reads, or network responses is a
+## `Vector{UInt8}`. Reshape transparently. Mirror `imread`'s default flag for
+## the no-flag form.
+imdecode(buf::AbstractVector{UInt8}, flags::Integer) =
+    imdecode(reshape(buf, 1, 1, :), Int64(flags))
+imdecode(buf::AbstractVector{UInt8}) =
+    imdecode(buf, Int64(cv_IMREAD_COLOR_BGR))

--- a/test/test_fileio.jl
+++ b/test/test_fileio.jl
@@ -61,3 +61,13 @@ end
         @test img1 == img2
     end
 end
+
+@testset "issue #58: imdecode(Vector{UInt8})" begin
+    img = rand(UInt8, 3, 64, 48)
+    _, buf = OpenCV.imencode(".png", img)
+    @test buf isa Vector{UInt8}
+    decoded = OpenCV.imdecode(buf, -1)
+    @test size(decoded) == size(img)
+    @test decoded == img
+    @test size(OpenCV.imdecode(buf)) == size(img)
+end


### PR DESCRIPTION
## Summary
- The auto-generated `imdecode(buf::InputArray, flags::Int64)` requires the encoded byte buffer to already be a 3D `InputArray`, but the natural form returned by `imencode`, `read`, or network responses is a flat `Vector{UInt8}`.
- Adds an overload that reshapes the buffer to `(1, 1, :)` and forwards, plus a one-arg form defaulting to `cv_IMREAD_COLOR_BGR` to mirror `imread`'s signature.
- The same reshape was already in use as a private workaround inside `load(::Stream)` in `src/fileio.jl`.

Fixes #58.

## Test plan
- [x] Local `Pkg.test()` passes (161 tests, +4 new in `test_fileio.jl`).
- [x] Round-trip `imencode` → `imdecode(::Vector{UInt8})` recovers the original image bit-for-bit (PNG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)