### PR TITLE
Fix VideoWriter_fourcc dispatch and add String form

### DIFF
--- a/src/OpenCV.jl
+++ b/src/OpenCV.jl
@@ -6,6 +6,7 @@ using FileIO: DataFormat, File, Stream, stream
 
 include(joinpath(OpenCV_jll.artifact_dir, "OpenCV", "src", "OpenCV.jl"))
 
+include("patches_video.jl")
 include("fileio.jl")
 include("show.jl")
 

--- a/src/patches_video.jl
+++ b/src/patches_video.jl
@@ -1,0 +1,16 @@
+## Issue #31: the auto-generated `VideoWriter_fourcc(::Char, ::Char, ::Char,
+## ::Char)` forwards `Char` values to a C++ binding that only accepts `Cchar`
+## (`Int8`), so every call raises `MethodError`. The wrapper itself goes
+## through `julia_to_cpp` for each argument, so registering a Char conversion
+## is enough to fix dispatch without overwriting the wrapper method (which
+## Julia 1.12 rejects during precompilation). `VideoWriter_fourcc` is the
+## only wrapper that uses `::Char`.
+
+julia_to_cpp(c::Char) = Cchar(c)
+
+# Convenience form mirroring Python's `cv.VideoWriter_fourcc(*"h264")`.
+function VideoWriter_fourcc(s::AbstractString)
+    length(s) == 4 ||
+        throw(ArgumentError("VideoWriter_fourcc expects a 4-character codec tag, got $(repr(s))"))
+    VideoWriter_fourcc(s[1], s[2], s[3], s[4])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,4 +22,5 @@ end
     include("test_fileio.jl")
     include("test_corner_detection.jl")
     include("test_calibration.jl")
+    include("test_video.jl")
 end

--- a/test/test_video.jl
+++ b/test/test_video.jl
@@ -1,0 +1,9 @@
+@testset "issue #31: VideoWriter_fourcc" begin
+    # Reference value from Python: cv2.VideoWriter_fourcc(*"h264") == 875967080.
+    @test OpenCV.VideoWriter_fourcc("h264"...) == 875967080
+    @test OpenCV.VideoWriter_fourcc("h264") == 875967080
+    @test OpenCV.VideoWriter_fourcc("mp4v") == 1983148141
+    @test OpenCV.VideoWriter_fourcc("h264"...) == OpenCV.VideoWriter_fourcc("h264")
+    @test_throws ArgumentError OpenCV.VideoWriter_fourcc("h26")
+    @test_throws ArgumentError OpenCV.VideoWriter_fourcc("h2645")
+end


### PR DESCRIPTION
## Summary
- The auto-generated `VideoWriter_fourcc(::Char, ::Char, ::Char, ::Char)` forwards `Char` values through `julia_to_cpp` to a C++ binding that only accepts `Cchar` (`Int8`), so every call raised `MethodError`.
- Registering `julia_to_cpp(c::Char) = Cchar(c)` is enough to fix dispatch: the wrapper itself already routes each argument through `julia_to_cpp`, and `VideoWriter_fourcc` is the only generated wrapper that takes a `::Char` argument. This avoids overwriting the wrapper method, which Julia 1.12 turns into a hard precompilation error.
- Adds a `VideoWriter_fourcc(::AbstractString)` form that mirrors Python's idiomatic `cv.VideoWriter_fourcc(*"h264")`.

Fixes #31.

## Test plan
- [x] Local `Pkg.test()` passes (163 tests, +6 new in `test_video.jl`).
- [x] `VideoWriter_fourcc("h264")` returns `875967080`, matching Python's reference value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)