### PR TITLE
Add regression test for split + downstream use (closes #5)

### DIFF
--- a/test/test_mat.jl
+++ b/test/test_mat.jl
@@ -114,3 +114,25 @@ end
     @test checkbounds(Bool, A, [CartesianIndex((5, 5))], 3) == false
     @test checkbounds(Bool, A, [CartesianIndex((5, 4))], 4) == false
 end
+
+@testset "issue #5: split output is usable downstream" begin
+    # Regression test for https://github.com/JuliaImages/OpenCV.jl/issues/5
+    # The original report (CxxWrap 0.10 era) saw split return Mats whose
+    # backing CxxMat was a CxxMatDereferenced that no cpp_to_julia method
+    # matched, raising MethodError. Modern CxxWrap makes
+    # CxxMatDereferenced <: CxxMat so the existing method matches; lock
+    # that in here.
+    img = OpenCV.Mat(rand(UInt8, 3, 8, 8))
+    ym = OpenCV.cvtColor(img, OpenCV.COLOR_BGR2LAB)
+    channels = OpenCV.split(ym)
+    @test channels isa AbstractVector
+    @test length(channels) == 3
+    for c in channels
+        @test size(c) == (1, 8, 8)
+        @test c isa OpenCV.Mat
+        # Touch the data: this exercises the unsafe_wrap path that used
+        # to crash when the backing CxxMat was dereferenced incorrectly.
+        @test sum(Int, c) >= 0
+        @test c[1, 1, 1] isa UInt8
+    end
+end


### PR DESCRIPTION
## Summary
- Issue #5 reported `MethodError: no method matching jlopencv_core_Mat_mutable_data(::OpenCV.CxxMatDereferenced)` from `OpenCV.split` (CxxWrap 0.10 era).
- With current CxxWrap, `CxxMatDereferenced <: CxxMat`, so the existing `cpp_to_julia(::CxxMat)` method matches and the original repro from the issue runs cleanly. No source change is needed.
- This PR adds a regression test that exercises `split` → `size` / `getindex` / `sum` on each returned channel, so we'll notice if the type relationship regresses again.

Closes #5.

## Test plan
- [x] Local `Pkg.test()` passes (171 tests, +8 new in `test_mat.jl`).
- [x] Original repro from issue #5 (`cvtColor(BGR2LAB)` + `split`) runs without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)