### PR TITLE
Tighten Mat/Vec/cv_cxx/fileio hygiene

### DIFF
--- a/src/Mat.jl
+++ b/src/Mat.jl
@@ -2,18 +2,14 @@
 
 struct Mat{T <: dtypes} <: AbstractArray{T,3}
     mat
-    data_raw
     data
 
-    @inline function Mat{T}(mat, data_raw::AbstractArray{T,3}) where {T <: dtypes}
-        data = reinterpret(T, data_raw)
-        new{T}(mat, data_raw, data)
+    @inline function Mat{T}(mat, data::AbstractArray{T,3}) where {T <: dtypes}
+        new{T}(mat, data)
     end
 
-    @inline function Mat(data_raw::AbstractArray{T, 3}) where {T <: dtypes}
-        data = reinterpret(T, data_raw)
-        mat = nothing
-        new{T}(mat, data_raw, data)
+    @inline function Mat(data::AbstractArray{T, 3}) where {T <: dtypes}
+        new{T}(nothing, data)
     end
 end
 
@@ -31,7 +27,7 @@ Base.axes(A::Mat) = axes(A.data)
 Base.IndexStyle(::Type{Mat{T}}) where {T} = IndexCartesian()
 
 Base.strides(A::Mat{T}) where {T} = strides(A.data)
-Base.copy(A::Mat{T}) where {T} = Mat(copy(A.data_raw))
+Base.copy(A::Mat{T}) where {T} = Mat(copy(A.data))
 Base.pointer(A::Mat) = Base.pointer(A.data)
 
 Base.unsafe_convert(::Type{Ptr{T}}, A::Mat{S}) where {T, S} = Base.unsafe_convert(Ptr{T}, A.data)

--- a/src/Vec.jl
+++ b/src/Vec.jl
@@ -3,17 +3,15 @@
 struct Vec{T, N} <: AbstractArray{T,1}
     cpp_object
     data::AbstractArray{T, 1}
-    cpp_allocated::Bool
-    @inline function Vec{T, N}(obj) where {T, N}
 
-        new{T, N}(obj, Base.unsafe_wrap(Array{T, 1}, Ptr{T}(obj.cpp_object), N), true)
+    @inline function Vec{T, N}(obj) where {T, N}
+        new{T, N}(obj, Base.unsafe_wrap(Array{T, 1}, Ptr{T}(obj.cpp_object), N))
     end
 
-    @inline function Vec{T, N}(data_raw::AbstractArray{T, 1}) where {T, N}
-        if size(data_raw, 1) != N
-            throw("Array is improper Size for Vec declared")
-        end
-        new{T, N}(nothing, data_raw, false)
+    @inline function Vec{T, N}(data::AbstractArray{T, 1}) where {T, N}
+        size(data, 1) == N ||
+            throw(DimensionMismatch("Vec{$T, $N} expects a length-$N array, got length $(size(data, 1))"))
+        new{T, N}(nothing, data)
     end
 end
 

--- a/src/cv_cxx.jl
+++ b/src/cv_cxx.jl
@@ -5,16 +5,16 @@ using OpenCV_jll
 include("typestructs.jl")
 include("Vec.jl")
 const dtypes = Union{UInt8, Int8, UInt16, Int16, Int32, Float32, Float64}
-size_t = UInt64
+
+# `size_t` is referenced verbatim by the generated wrappers (e.g.
+# `maxIters::size_t` in `estimateAffine2D`). `Csize_t` resolves to the
+# platform's pointer-width unsigned, matching C `size_t`.
+const size_t = Csize_t
 
 using CxxWrap
 @wrapmodule(OpenCV_jll.get_libopencv_julia_path, :cv_wrap)
 function __init__()
     @initcxx
-
-    if jlopencv_core_get_sizet()==4
-        size_t = UInt32
-    end
 end
 const Scalar = Union{Tuple{}, Tuple{Number}, Tuple{Number, Number}, Tuple{Number, Number, Number}, NTuple{4, Number}}
 

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -17,7 +17,7 @@ function load(f::File{T}) where {T<:_IMAGE_DATA_FORMATS}
     return data
 end
 
-function load(f::File{T}, flags::Int) where {T<:_IMAGE_DATA_FORMATS}
+function load(f::File{T}, flags::Int64) where {T<:_IMAGE_DATA_FORMATS}
     data = imread(f.filename, flags)
     return data
 end
@@ -28,7 +28,7 @@ function load(s::Stream{T}) where {T<:_IMAGE_DATA_FORMATS}
     return img
 end
 
-function load(s::Stream{T}, flags::Int) where {T<:_IMAGE_DATA_FORMATS}
+function load(s::Stream{T}, flags::Int64) where {T<:_IMAGE_DATA_FORMATS}
     data = read(stream(s))
     img = imdecode(reshape(data, 1, 1, :), flags)
     return img
@@ -40,7 +40,7 @@ function save(f::File{T}, image::InputArray) where {T<:_IMAGE_DATA_FORMATS}
     imwrite(f.filename, image)
 end
 
-function save(f::File{T}, image::InputArray, params::Array{Int32,1}) where {T<:_IMAGE_DATA_FORMATS}
+function save(f::File{T}, image::InputArray, params::Vector{Int32}) where {T<:_IMAGE_DATA_FORMATS}
     imwrite(f.filename, image, params)
 end
 


### PR DESCRIPTION
A few low-risk cleanups to the non-generated source files now that the generator and wrappers live in the repo.

## Changes

- **`cv_cxx.jl`**: `size_t = UInt64` was a non-`const` module global, and the runtime branch in `__init__` that rebound it to `UInt32` on 32-bit platforms was dead code (local assignment, never updated the module global). Replaced with `const size_t = Csize_t`, which resolves to the platform's pointer-width unsigned and matches C `size_t`. The literal `size_t` is referenced verbatim by the generated wrappers (e.g. `maxIters::size_t` in `estimateAffine2D`), so the name has to stay.
- **`Mat.jl`**: held two fields, `data_raw` and `data = reinterpret(T, data_raw)`. With the constructor signature pinning `data_raw::AbstractArray{T,3}`, the reinterpret is a no-op (same eltype). Dropped `data_raw`; kept the single `data` field that every method already used.
- **`Vec.jl`**: dropped the unused `cpp_allocated` field. Changed the size mismatch from `throw("...")` (a bare String) to a proper `DimensionMismatch` so callers can catch it normally.
- **`fileio.jl`**: normalized `flags::Int` → `Int64` (matching the generated `imread`/`imdecode` signatures) and `Array{Int32,1}` → `Vector{Int32}`.

## What I attempted but backed out

I drafted a refactor of `mat_conversion.jl` to replace the 7-way `if eltype(img) == UInt8 … elseif Float64 …` cascades with a small `Dict` lookup. Two surprises convinced me to drop it:

1. `Base.get` is shadowed by the generated `OpenCV.get` methods (`VideoCapture.get`, `VideoWriter.get`), so `get(_CV_DTYPE, …)` resolves to the wrong method. Fixable with explicit `Base.get`.
2. Even after that fix, swapping `steps_a = Array{size_t,1}(); push!(…)` for the byte-equivalent literal form `size_t[a, b, c]` makes `cvtColor` segfault — both produce the same `Vector{UInt64}` standalone, so it's some subtle interaction with how Julia/CxxWrap keeps the pointer alive across the C call.

This file is interop-sensitive enough that \"obviously equivalent\" Julia rewrites aren't. Not worth the risk for a style refactor.

## Test plan

- [x] `Pkg.test()` — all 192 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)