### PR TITLE
gen: compile cv_core.cpp as C++17 (fix macOS libc++ build)

### DIFF
--- a/gen/CMakeLists.txt
+++ b/gen/CMakeLists.txt
@@ -121,6 +121,17 @@ ocv_glob_module_sources()
 ocv_module_include_directories()
 ocv_warnings_disable(CMAKE_CXX_FLAGS -Wmissing-prototypes -Wmissing-declarations)
 
+# Compile the generated cv_core.cpp as C++17. On a newer macOS SDK (libc++),
+# building in C++20 makes the standard library eagerly instantiate std::operator<
+# for std::vector<cv::Mat> / std::vector<cv::Point2f> when jlcxx probes a method's
+# return type (julia_return_type). Those OpenCV types have no bool operator<, so
+# the translation unit fails to compile. (libstdc++ on Linux does not instantiate
+# these eagerly, which is why only macOS is affected.) JlCxx requires cxx_std_20,
+# so we cannot lower the target's standard; instead append -std=c++17 to just this
+# one TU — clang uses the last -std on the command line, so it wins.
+set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/gen/autogen_cpp/cv_core.cpp"
+                            PROPERTIES COMPILE_OPTIONS "-std=c++17")
+
 ocv_add_library(${the_module} SHARED ${OPENCV_MODULE_${the_module}_HEADERS}
                                      ${OPENCV_MODULE_${the_module}_SOURCES}
                                      "${CMAKE_CURRENT_BINARY_DIR}/gen/autogen_cpp/cv_core.cpp")


### PR DESCRIPTION
## Problem

Building `OpenCV_jll` for macOS with a recent SDK (libc++) fails to compile the generated `cv_core.cpp`:

```
__algorithm/comp.h:47: error: invalid operands to binary expression
   ('const cv::Point_<float>' and 'const cv::Point_<float>')
... no viable conversion from returned value of type 'MatExpr' to function return type 'bool'
```

In **C++20**, libc++ eagerly instantiates `std::operator<` for `std::vector<…>` (the ranges comparison machinery) when jlcxx's `julia_return_type` probes a wrapped method's return type. Two bindings return containers of non-`bool`-comparable OpenCV types:

- `cv::Subdiv2D::getVoronoiFacetList` → `vector<vector<cv::Point2f>>` (`Point2f` has no `operator<`)
- a `cv::dnn::Net` overload → `vector<vector<cv::Mat>>` (`cv::Mat::operator<` returns `MatExpr`, not `bool`)

**libstdc++ on Linux does not instantiate these eagerly**, which is why only macOS was affected.

## Fix

`JlCxx` requires `cxx_std_20`, so we can't lower the module's standard. Instead, force just `cv_core.cpp` to **C++17** via `set_source_files_properties(... COMPILE_OPTIONS "-std=c++17")` — clang uses the last `-std` on the command line, so it wins over the inherited `-std=c++20`. C++17 doesn't have the ranges-comparison machinery that triggers the eager instantiation.

## Validation

Reproduced and fixed in a BinaryBuilder sandbox for `aarch64-apple-darwin` against the macOS 14.0 SDK: `cv_core.cpp` compiles cleanly (0 errors) with the override, and `build.make` confirms `-std=c++17` is applied last to that TU. Linux/Windows are unaffected.

Needed by the Yggdrasil `OpenCV_jll` rebuild that uses a recent macOS SDK for Qt/AVFoundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)