### PR TITLE
Fix segfault accessing split() output (#57)

### DIFF
--- a/src/mat_conversion.jl
+++ b/src/mat_conversion.jl
@@ -100,7 +100,13 @@ end
 function cpp_to_julia(var::CxxWrap.StdVector{T}) where {T <: CxxMat}
     ret = Array{Mat, 1}()
     for x in var
-        push!(ret, cpp_to_julia(x))
+        m = cpp_to_julia(x)
+        # Iterating a StdVector yields elements whose lifetime is tied to
+        # the parent vector. Preserve `var` (which transitively keeps each
+        # cv::Mat and its data buffer alive) in the returned Mat so the
+        # underlying memory isn't freed while the Mat is still in use.
+        # See https://github.com/JuliaImages/OpenCV.jl/issues/57.
+        push!(ret, Mat{eltype(m)}((var, m.mat), m.data))
     end
     return ret
 end

--- a/src/mat_conversion.jl
+++ b/src/mat_conversion.jl
@@ -101,11 +101,7 @@ function cpp_to_julia(var::CxxWrap.StdVector{T}) where {T <: CxxMat}
     ret = Array{Mat, 1}()
     for x in var
         m = cpp_to_julia(x)
-        # Iterating a StdVector yields elements whose lifetime is tied to
-        # the parent vector. Preserve `var` (which transitively keeps each
-        # cv::Mat and its data buffer alive) in the returned Mat so the
-        # underlying memory isn't freed while the Mat is still in use.
-        # See https://github.com/JuliaImages/OpenCV.jl/issues/57.
+        # Preserve parent StdVector: iterated CxxMat refs alias it (#57).
         push!(ret, Mat{eltype(m)}((var, m.mat), m.data))
     end
     return ret

--- a/test/test_mat.jl
+++ b/test/test_mat.jl
@@ -136,3 +136,32 @@ end
         @test c[1, 1, 1] isa UInt8
     end
 end
+
+@testset "issue #57: split output survives GC" begin
+    # Regression test for https://github.com/JuliaImages/OpenCV.jl/issues/57
+    # cv::split returns vector<Mat>; the Julia wrappers must keep the parent
+    # StdVector alive so the underlying data buffers aren't freed once GC
+    # collects intermediate references. Without the fix, reading channels[i]
+    # after a GC raises EXCEPTION_ACCESS_VIOLATION / segfault on large mats.
+    function make_channels()
+        img = OpenCV.Mat(rand(UInt8, 3, 512, 512))
+        return OpenCV.split(img)
+    end
+    channels = make_channels()
+    GC.gc(); GC.gc()
+    @test length(channels) == 3
+    for c in channels
+        @test size(c) == (1, 512, 512)
+        # Touch every element to ensure the buffer is still mapped.
+        s = 0
+        for k in axes(c, 3), j in axes(c, 2)
+            s += c[1, j, k]
+        end
+        @test s >= 0
+    end
+    # Second GC + read pass: catches the case where the first access path
+    # happened to keep things alive but later accesses crash.
+    GC.gc(); GC.gc()
+    @test channels[1][1, 1, 1] isa UInt8
+    @test channels[end][1, end, end] isa UInt8
+end

--- a/test/test_mat.jl
+++ b/test/test_mat.jl
@@ -139,10 +139,6 @@ end
 
 @testset "issue #57: split output survives GC" begin
     # Regression test for https://github.com/JuliaImages/OpenCV.jl/issues/57
-    # cv::split returns vector<Mat>; the Julia wrappers must keep the parent
-    # StdVector alive so the underlying data buffers aren't freed once GC
-    # collects intermediate references. Without the fix, reading channels[i]
-    # after a GC raises EXCEPTION_ACCESS_VIOLATION / segfault on large mats.
     function make_channels()
         img = OpenCV.Mat(rand(UInt8, 3, 512, 512))
         return OpenCV.split(img)
@@ -152,15 +148,12 @@ end
     @test length(channels) == 3
     for c in channels
         @test size(c) == (1, 512, 512)
-        # Touch every element to ensure the buffer is still mapped.
         s = 0
         for k in axes(c, 3), j in axes(c, 2)
             s += c[1, j, k]
         end
         @test s >= 0
     end
-    # Second GC + read pass: catches the case where the first access path
-    # happened to keep things alive but later accesses crash.
     GC.gc(); GC.gc()
     @test channels[1][1, 1, 1] isa UInt8
     @test channels[end][1, end, end] isa UInt8


### PR DESCRIPTION
## Summary
- Fixes #57: `EXCEPTION_ACCESS_VIOLATION` / segfault when accessing channels returned by `OpenCV.split` on larger images.
- Root cause: `cv::split` returns `vector<Mat>`. The wrapper iterated the `StdVector{CxxMat}` and only stored each iterated `CxxMat` reference in `Mat.mat`. Those references' lifetime is tied to the parent `StdVector`, so once the vector was GC'd the underlying `cv::Mat` data buffers were freed, and subsequent accesses hit deallocated memory.
- Fix: preserve the parent `StdVector` alongside each iterated `CxxMat` inside the returned `Mat.mat` field so the data buffers stay alive for the lifetime of any returned `Mat`.

## Test plan
- [x] Added regression test `issue #57: split output survives GC` in `test/test_mat.jl` that splits a 3×512×512 image, forces `GC.gc()`, and reads every element of every channel.
- [x] Reproducer from the issue (`OpenCV.Mat(ones(UInt8, 3, 4000, 4000))` → `split` → access `ch[1]`) no longer crashes.
- [x] `test/test_mat.jl` passes locally (including existing tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)