### PR TITLE
Add external GC pressure hint for cv::Mat buffers (#10)

### DIFF
--- a/src/mat_conversion.jl
+++ b/src/mat_conversion.jl
@@ -40,8 +40,24 @@ function cpp_to_julia(mat::CxxMat)
     #TODO: Implement views when steps do not result in continous memory
     arr = Base.unsafe_wrap(Array{dtype, 3}, Ptr{dtype}(rets[1].cpp_object), (rets[3], rets[4], rets[5]))
 
+    # Off-heap pressure hint (#10).
+    _gc_external_pressure!(rets[3] * rets[4] * rets[5] * sizeof(dtype))
+
     #Preserve Mat so that array allocated by C++ isn't deallocated
     return Mat{dtype}(mat, arr)
+end
+
+# Off-heap byte counter for cv::Mat buffers; flush via incremental GC (#10).
+const _gc_external_bytes = Threads.Atomic{Int64}(0)
+const _gc_external_threshold = Ref{Int64}(256 * 1024 * 1024)
+
+function _gc_external_pressure!(nbytes::Integer)
+    total = Threads.atomic_add!(_gc_external_bytes, Int64(nbytes)) + Int64(nbytes)
+    if total >= _gc_external_threshold[]
+        Threads.atomic_sub!(_gc_external_bytes, total)
+        GC.gc(false)
+    end
+    return nothing
 end
 
 function julia_to_cpp(img::InputArray)

--- a/test/test_mat.jl
+++ b/test/test_mat.jl
@@ -158,3 +158,21 @@ end
     @test channels[1][1, 1, 1] isa UInt8
     @test channels[end][1, end, end] isa UInt8
 end
+
+@testset "issue #10: external memory pressure triggers GC" begin
+    # Regression test for https://github.com/JuliaImages/OpenCV.jl/issues/10
+    old_threshold = OpenCV._gc_external_threshold[]
+    OpenCV._gc_external_threshold[] = 8 * 1024 * 1024
+    OpenCV._gc_external_bytes[] = 0
+    try
+        src = OpenCV.Mat(rand(UInt8, 3, 1024, 1024))
+        GC.gc(); GC.gc()
+        pauses_before = Base.gc_num().pause
+        for _ in 1:50
+            _ = OpenCV.cvtColor(src, OpenCV.COLOR_BGR2GRAY)
+        end
+        @test Base.gc_num().pause > pauses_before
+    finally
+        OpenCV._gc_external_threshold[] = old_threshold
+    end
+end


### PR DESCRIPTION
## Summary
Fixes #10: native memory keeps growing in tight loops like `for i in 1:N; cv.read(vcap); end` until the user manually calls `GC.gc()`.

Root cause: `cv::Mat` pixel buffers live in C++ memory. The Julia `Mat` wrapper is only a couple of words on the Julia heap, so Julia's GC pacer sees almost no allocation pressure and never fires — meanwhile each iteration drops a multi-MB native buffer on the floor. CxxWrap's finalizer on `cv::Mat` is correctly wired; it just isn't invoked because GC never runs.

Approach: track off-heap bytes in OpenCV.jl and trigger `GC.gc(false)` (an incremental collection) once a threshold (default 256 MiB) is crossed. There is no public Julia API in 1.10 for registering external memory pressure, hence the in-package counter. Once GC runs, the existing CxxWrap finalizers release the buffers.

## Interaction with normal Julia GC
The CxxWrap finalizer on `cv::Mat` runs whenever GC visits an unreachable `CxxMat`, regardless of why GC fired. So any normal Julia-side allocation pressure already triggers GC and releases OpenCV buffers — this hint is only a safety net for the pathological native-only loop in #10 where Julia genuinely sees no heap activity.

Caveat: the counter only resets when *our* threshold fires, not when Julia GC fires for other reasons. In a mixed workload it can drift upward and eventually trigger a redundant `GC.gc(false)` after Julia already collected the CxxMats. Cost is one extra incremental GC per ~256 MiB of OpenCV throughput — cheap and harmless. We could subscribe to `ijl_gc_set_cb_notify_gc_pressure` to reset the counter on every GC, but it's not worth the complexity for the symptom.

## Test plan
- [x] New regression test `issue #10: external memory pressure triggers GC` in `test/test_mat.jl` lowers the threshold to 8 MiB and confirms `Base.gc_num().pause` increases over a 50-iteration `cvtColor` loop.
- [x] Verified locally that without the hint, `pauses_before == pauses_after` (no GC during the loop), and with the hint, GC fires.
- [x] Existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)