### PR TITLE
Tighten CxxWrap compat to 0.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,6 @@ OpenCV_jll = "33b9d88c-85f9-5d73-bd91-4e2b95a9aa0b"
 
 [compat]
 CxxWrap = "0.17"
-FileIO = "1.16, 1.17"
+FileIO = "1.17"
 OpenCV_jll = "4.13"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenCV"
 uuid = "f878e3a2-a245-4720-8660-60795d644f2a"
 authors = ["Archit Rungta <architrungta120@gmail.com>"]
-version = "4.9.1"
+version = "4.10.0"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenCV"
 uuid = "f878e3a2-a245-4720-8660-60795d644f2a"
 authors = ["Archit Rungta <architrungta120@gmail.com>"]
-version = "4.9.0"
+version = "4.9.1"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
@@ -9,7 +9,7 @@ FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 OpenCV_jll = "33b9d88c-85f9-5d73-bd91-4e2b95a9aa0b"
 
 [compat]
-CxxWrap = "0.16, 0.17"
+CxxWrap = "0.17"
 FileIO = "1.16, 1.17"
 OpenCV_jll = "4.13"
 julia = "1.10"


### PR DESCRIPTION
## Summary
`OpenCV_jll` pins `libcxxwrap_julia_jll = 0.14.7`, which requires **CxxWrap ≥ 0.17.4** (registry `C/CxxWrap/Compat.toml`). The old `"0.16, 0.17"` left `0.16` admissible — and 0.16 needs libcxxwrap 0.13, so in any resolve where the JLL doesn't transitively force libcxxwrap the solver can pick 0.16 and hit the `invalid subtyping StdString/CppBasicString` load crash. Drop the dead `0.16`.

## Verification
- Clean resolve picks CxxWrap 0.17.5; full suite **230/230**.
- The `min` CI job (Julia 1.10) still resolves — 0.17.4 supports Julia ≥ 1.6 and libcxxwrap 0.14.7.

> Stacked on #90 (base will retarget to `master` once that merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)