### PR TITLE
Restructure the conversion/bootstrap layer

### DIFF
--- a/src/OpenCV.jl
+++ b/src/OpenCV.jl
@@ -20,9 +20,9 @@ import Base.size
 # Julia wrapper bindings. Previously these were generated at OpenCV binary-build
 # time and shipped inside OpenCV_jll; they now live in this repository (see gen/)
 # and are regenerated with `julia gen/regenerate.jl` on an OpenCV version bump.
-# `cv_cxx.jl` loads the compiled glue via OpenCV_jll.get_libopencv_julia_path and
+# `core.jl` loads the compiled glue via OpenCV_jll.get_libopencv_julia_path and
 # pulls in the static helpers plus generated/cv_cxx_wrap.jl.
-include("cv_cxx.jl")
+include("core.jl")
 include("generated/cv_wrap.jl")
 
 include("fileio.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,4 +1,17 @@
-# using StaticArrays
+# Module bootstrap. Loads the compiled glue, registers the C++ types, and
+# orchestrates the include order of the hand-written and generated sources.
+#
+# Load-order invariant (each step depends on the ones above it):
+#   1. `@wrapmodule` registers the wrapped C++ types (CxxMat, CxxScalar, CxxVec,
+#      KeyPoint, DMatch, CxxBool, …) — everything below may reference them.
+#   2. the `dtypes` / `size_t` / `Scalar` / `InputArray` consts.
+#   3. errors.jl   — defines OpenCVError, used by mat_conversion.jl.
+#   4. Mat.jl, then the `InputArray` const (needs CxxMat from step 1).
+#   5. mat_conversion.jl, then types_conversion.jl — the cpp_to_julia /
+#      julia_to_cpp methods (see types_conversion.jl for the contract).
+#   6. generated/cv_cxx_wrap.jl — the generated wrappers, which call those
+#      conversion methods, so they must be defined first.
+#   7. overrides/ — hand-written overrides of the generated wrappers.
 
 using OpenCV_jll
 
@@ -25,34 +38,6 @@ const InputArray = Union{AbstractArray{T, 3} where {T <: dtypes}, CxxMat}
 
 include("mat_conversion.jl")
 include("types_conversion.jl")
-
-function cpp_to_julia(var)
-    return var
-end
-function julia_to_cpp(var)
-    return var
-end
-
-function cpp_to_julia(var::Tuple)
-    ret_arr = Array{Any, 1}()
-    for it in var
-        push!(ret_arr, cpp_to_julia(it))
-    end
-    return tuple(ret_arr...)
-end
-
-function cpp_to_julia(var::CxxBool)
-    return Bool(var)
-end
-
-function julia_to_cpp(var::Bool)
-    return CxxBool(var)
-end
-
-# VideoWriter_fourcc is the one generated wrapper that takes Char arguments;
-# its C++ binding expects Cchar (Int8). See issue #31.
-julia_to_cpp(c::Char) = Cchar(c)
-
 
 include("generated/cv_cxx_wrap.jl")
 

--- a/src/types_conversion.jl
+++ b/src/types_conversion.jl
@@ -1,3 +1,31 @@
+# The cpp_to_julia / julia_to_cpp contract.
+#
+# Every value crossing the C++ boundary in the generated wrappers passes through
+# one of these two functions: `cpp_to_julia` converts a value returned from C++
+# into its Julia form, `julia_to_cpp` converts a Julia argument into the form the
+# C++ glue expects. The generic identity methods below are the fallback (most
+# values, e.g. numbers, pass straight through); the specialised methods in this
+# file and in `mat_conversion.jl` convert by type. Both directions must be
+# defined before `generated/cv_cxx_wrap.jl` is included (see core.jl).
+
+cpp_to_julia(var) = var
+julia_to_cpp(var) = var
+
+function cpp_to_julia(var::Tuple)
+    ret_arr = Array{Any, 1}()
+    for it in var
+        push!(ret_arr, cpp_to_julia(it))
+    end
+    return tuple(ret_arr...)
+end
+
+cpp_to_julia(var::CxxBool) = Bool(var)
+julia_to_cpp(var::Bool) = CxxBool(var)
+
+# VideoWriter_fourcc is the one generated wrapper that takes Char arguments;
+# its C++ binding expects Cchar (Int8). See issue #31.
+julia_to_cpp(c::Char) = Cchar(c)
+
 function cpp_to_julia(var::CxxScalar{T}) where {T}
     var = Vec{T, 4}(var)
     return (var[1], var[2], var[3], var[4])
@@ -20,25 +48,12 @@ function julia_to_cpp(sc::Scalar)
     return CxxScalar{Float64}(Float64(sc[1]), Float64(sc[2]), Float64(sc[3]), Float64(sc[4]))
 end
 
-function julia_to_cpp(vec::Vec{T, N}) where {T, N}
-    return CxxVec{T, N}(Base.pointer(vec))
-end
-
-function julia_to_cpp(var::Array{T, 1}) where {T <: Scalar}
-    ret = CxxWrap.StdVector{CxxScalar}()
-    for x in var
-        push!(ret, julia_to_cpp(x))
-    end
-    return ret
-end
-
-function julia_to_cpp(var::Array{Vec{T, N}, 1}) where {T, N}
-    ret = CxxWrap.StdVector{CxxVec{T, N}}()
-    for x in var
-        push!(ret, julia_to_cpp(x))
-    end
-    return ret
-end
+# Note: there is no `julia_to_cpp` for a bare `Vec`, a `Vector{<:Scalar}`, or a
+# `Vector{Vec}`. CxxWrap registers no `CxxVec{T,N}(::Ptr)` or `StdVector{CxxScalar}`
+# constructor, and no wrapped OpenCV function takes those argument shapes — the
+# reverse direction (reading a `cv::Scalar`/`cv::Vec` *out* of C++) is handled by
+# the `cpp_to_julia(::CxxScalar)` / `cpp_to_julia(::CxxVec)` methods above, and a
+# single `cv::Scalar` argument by `julia_to_cpp(::Scalar)`.
 
 function julia_to_cpp(var::Array{T, 1}) where {T}
     if size(var, 1) == 0

--- a/test/test_core_types.jl
+++ b/test/test_core_types.jl
@@ -1,6 +1,6 @@
 # Coverage for the hand-written core types and dispatch helpers:
 # Mat / Vec (AbstractArray interface), the typestructs, OpenCVError, and the
-# scalar cpp<->julia identity/Tuple/Bool conversions in cv_cxx.jl.
+# scalar cpp<->julia identity/Tuple/Bool conversions in types_conversion.jl.
 
 @testset "Mat AbstractArray interface" begin
     data = reshape(collect(UInt8, 1:24), 2, 3, 4)


### PR DESCRIPTION
A small, low-risk structural cleanup of the hand-written core (follow-up to the review in #92). **No behaviour change** except removing unreachable dead code; suite stays **310/310** locally.

## Changes
- **Rename `src/cv_cxx.jl` → `src/core.jl`.** The old name was easily confused with the *generated* `src/generated/cv_cxx_wrap.jl`. `core.jl` is now a pure bootstrap — `@wrapmodule`, the `dtypes`/`size_t`/`Scalar`/`InputArray` consts, include orchestration — with a comment documenting the **load-order invariant**. (The generated file and the `:cv_wrap` symbol are unrelated and untouched.)
- **Consolidate conversions.** Moved the five stray `cpp_to_julia`/`julia_to_cpp` methods (identity, `Tuple`, `CxxBool`/`Bool`, `Char`) out of the bootstrap file into the top of `types_conversion.jl`, with a comment stating the conversion **contract**. Load order is preserved (conversions are defined before the generated wrappers that call them).
- **Remove three dead, broken methods.** The write-direction `julia_to_cpp` for a bare `Vec`, `Vector{<:Scalar}`, and `Vector{Vec}` built CxxWrap types with no constructor (`StdVector{CxxScalar}`, `CxxVec{T,N}(::Ptr)`) and threw `MethodError` if called. Verified unreachable — no wrapped function takes those shapes. A comment documents the read/write asymmetry; the reachable read-direction conversions and the singular `julia_to_cpp(::Scalar)` (colour args) are kept.

## Verification
- Full suite **310/310** against a local `OpenCV_jll 4.13.0`.
- Smoke: `using OpenCV` loads, `getVersionString() == "4.13.0"`, `HoughLines` works.
- `grep -rn cv_cxx src test docs` clean except the generated file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)